### PR TITLE
Fix Xcode 8 error

### DIFF
--- a/Toaster.podspec
+++ b/Toaster.podspec
@@ -11,4 +11,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Sources/*.{swift,h}'
   s.frameworks   = 'UIKit', 'Foundation', 'QuartzCore'
   s.requires_arc = true
+  s.pod_target_xcconfig = {
+    'SWIFT_VERSION' => '3.0'
+  }
 end


### PR DESCRIPTION
Fixing this issue:

```
=== BUILD TARGET Toaster OF PROJECT Pods WITH CONFIGURATION Debug ===

Check dependencies
“Use Legacy Swift Language Version” (SWIFT_VERSION) is required to be configured correctly for targets which use Swift. Use the [Edit > Convert > To Current Swift Syntax…] menu to choose a Swift version or use the Build Settings editor to configure the build setting directly.
“Use Legacy Swift Language Version” (SWIFT_VERSION) is required to be configured correctly for targets which use Swift. Use the [Edit > Convert > To Current Swift Syntax…] menu to choose a Swift version or use the Build Settings editor to configure the build setting directly.

** BUILD FAILED **

```