### PR TITLE
fixing infinite recursion where the first window is a ToastWindow itself

### DIFF
--- a/Sources/ToastWindow.swift
+++ b/Sources/ToastWindow.swift
@@ -53,7 +53,8 @@ open class ToastWindow: UIWindow {
   override open var rootViewController: UIViewController? {
     get {
       guard !self.isStatusBarOrientationChanging else { return nil }
-      return UIApplication.shared.windows.first?.rootViewController
+      guard let firstWindow = UIApplication.shared.windows.first else { return nil }
+      return firstWindow is ToastWindow ? nil : firstWindow.rootViewController
     }
     set { /* Do nothing */ }
   }


### PR DESCRIPTION
fixing infinite recursion on Tests targets with an Host Application where the first window is a ToastWindow itself