### PR TITLE
Prevent crash when using a NativeScript app (for alternate icon name)

### DIFF
--- a/Sources/Toast.swift
+++ b/Sources/Toast.swift
@@ -49,7 +49,7 @@ open class Toast: Operation {
 
   // MARK: Initializing
 
-  public init(text: String?, delay: TimeInterval = 0, duration: TimeInterval = Delay.short) {
+  @objc public init(text: String?, delay: TimeInterval = 0, duration: TimeInterval = Delay.short) {
     self.delay = delay
     self.duration = duration
     super.init()
@@ -77,14 +77,14 @@ open class Toast: Operation {
 
   // MARK: Showing
 
-  public func show() {
+  @objc public func show() {
     ToastCenter.default.add(self)
   }
 
 
   // MARK: Cancelling
 
-  open override func cancel() {
+  @objc open override func cancel() {
     super.cancel()
     self.finish()
     self.view.removeFromSuperview()

--- a/Sources/ToastWindow.swift
+++ b/Sources/ToastWindow.swift
@@ -53,7 +53,9 @@ open class ToastWindow: UIWindow {
   override open var rootViewController: UIViewController? {
     get {
       guard !self.isStatusBarOrientationChanging else { return nil }
-      guard let firstWindow = UIApplication.shared.delegate?.window else { return nil }
+      guard let firstWindow = UIApplication.shared.delegate?.window else {
+        return UIApplication.shared.windows.first?.rootViewController
+      }
       return firstWindow is ToastWindow ? nil : firstWindow?.rootViewController
     }
     set { /* Do nothing */ }

--- a/Toaster.podspec
+++ b/Toaster.podspec
@@ -11,4 +11,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Sources/*.{swift,h}'
   s.frameworks   = 'UIKit', 'Foundation', 'QuartzCore'
   s.requires_arc = true
+  s.swift_version = '4.0'
 end


### PR DESCRIPTION
After showing a Toast my app would crash when using [this method](https://developer.apple.com/documentation/uikit/uiapplication/2806818-setalternateiconname).

I have very little experience in Swift so I don't know why the `rootViewController` getter needs to be hijacked by this pod, but to make it work for my case I'd really love to have this code merged.