### PR TITLE
Remove isExecuting check in `Toast.finish`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ doxygenWarnings.txt
 *.xcuserdatad
 
 *.xccheckout
+
+DerivedData/

--- a/Sources/Toast.swift
+++ b/Sources/Toast.swift
@@ -113,14 +113,15 @@ open class Toast: Operation {
   // MARK: Operation Subclassing
 
   override open func start() {
-    guard !self.isExecuting else { return }
+    let isRunnable = !self.isFinished && !self.isCancelled && !self.isExecuting
+    guard isRunnable else { return }
     guard Thread.isMainThread else {
       DispatchQueue.main.async { [weak self] in
         self?.start()
       }
       return
     }
-    super.start()
+    main()
   }
 
   override open func main() {
@@ -162,8 +163,7 @@ open class Toast: Operation {
     }
   }
 
-  open func finish() {
-    guard self.isExecuting else { return }
+  func finish() {
     self.isExecuting = false
     self.isFinished = true
   }

--- a/Sources/ToastCenter.swift
+++ b/Sources/ToastCenter.swift
@@ -30,7 +30,7 @@ open class ToastCenter {
   }()
 
   open var currentToast: Toast? {
-    return self.queue.operations.first as? Toast
+    return self.queue.operations.first { !$0.isCancelled && !$0.isFinished } as? Toast
   }
 
   open static let `default` = ToastCenter()
@@ -58,9 +58,7 @@ open class ToastCenter {
   // MARK: Cancelling Toasts
 
   open func cancelAll() {
-    for toast in self.queue.operations {
-      toast.cancel()
-    }
+    queue.cancelAllOperations()
   }
 
 

--- a/Toaster.xcodeproj/project.pbxproj
+++ b/Toaster.xcodeproj/project.pbxproj
@@ -17,10 +17,19 @@
 		0397CD2D1D85D6920077D82F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0306DB991D85D626007AE314 /* AppDelegate.swift */; };
 		0397CD2E1D85D6930077D82F /* RootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0306DB9E1D85D626007AE314 /* RootViewController.swift */; };
 		03C23F3C1D8823AA00EE8424 /* Toaster.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03A75E2B1BCF2066002E46C4 /* Toaster.framework */; };
+		C06FC9D41F95A8CC00782082 /* ToasterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06FC9D31F95A8CC00782082 /* ToasterTests.swift */; };
+		C06FC9D61F95A8CC00782082 /* Toaster.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03A75E2B1BCF2066002E46C4 /* Toaster.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
 		03A75E631BCF216A002E46C4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03A75E221BCF2066002E46C4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 03A75E2A1BCF2066002E46C4;
+			remoteInfo = Toaster;
+		};
+		C06FC9D71F95A8CC00782082 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 03A75E221BCF2066002E46C4 /* Project object */;
 			proxyType = 1;
@@ -43,6 +52,9 @@
 		0306DBB01D85D62E007AE314 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		03A75E2B1BCF2066002E46C4 /* Toaster.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Toaster.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		03A75E4F1BCF20D4002E46C4 /* ToasterDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ToasterDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C06FC9D11F95A8CC00782082 /* ToasterTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ToasterTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C06FC9D31F95A8CC00782082 /* ToasterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToasterTests.swift; sourceTree = "<group>"; };
+		C06FC9D51F95A8CC00782082 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -58,6 +70,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				03C23F3C1D8823AA00EE8424 /* Toaster.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C06FC9CE1F95A8CC00782082 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C06FC9D61F95A8CC00782082 /* Toaster.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -102,6 +122,7 @@
 				0306DBA41D85D62A007AE314 /* Sources */,
 				0306DBAF1D85D62E007AE314 /* Supporting Files */,
 				0306DB981D85D626007AE314 /* Demo */,
+				C06FC9D21F95A8CC00782082 /* ToasterTests */,
 				03A75E2C1BCF2066002E46C4 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -111,8 +132,18 @@
 			children = (
 				03A75E2B1BCF2066002E46C4 /* Toaster.framework */,
 				03A75E4F1BCF20D4002E46C4 /* ToasterDemo.app */,
+				C06FC9D11F95A8CC00782082 /* ToasterTests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		C06FC9D21F95A8CC00782082 /* ToasterTests */ = {
+			isa = PBXGroup;
+			children = (
+				C06FC9D31F95A8CC00782082 /* ToasterTests.swift */,
+				C06FC9D51F95A8CC00782082 /* Info.plist */,
+			);
+			path = ToasterTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -165,13 +196,31 @@
 			productReference = 03A75E4F1BCF20D4002E46C4 /* ToasterDemo.app */;
 			productType = "com.apple.product-type.application";
 		};
+		C06FC9D01F95A8CC00782082 /* ToasterTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C06FC9DB1F95A8CC00782082 /* Build configuration list for PBXNativeTarget "ToasterTests" */;
+			buildPhases = (
+				C06FC9CD1F95A8CC00782082 /* Sources */,
+				C06FC9CE1F95A8CC00782082 /* Frameworks */,
+				C06FC9CF1F95A8CC00782082 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C06FC9D81F95A8CC00782082 /* PBXTargetDependency */,
+			);
+			name = ToasterTests;
+			productName = ToasterTests;
+			productReference = C06FC9D11F95A8CC00782082 /* ToasterTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		03A75E221BCF2066002E46C4 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0700;
+				LastSwiftUpdateCheck = 0900;
 				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = "Suyeol Jeon";
 				TargetAttributes = {
@@ -182,6 +231,10 @@
 					03A75E4E1BCF20D4002E46C4 = {
 						CreatedOnToolsVersion = 7.0.1;
 						LastSwiftMigration = 0900;
+					};
+					C06FC9D01F95A8CC00782082 = {
+						CreatedOnToolsVersion = 9.0;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -200,6 +253,7 @@
 			targets = (
 				03A75E2A1BCF2066002E46C4 /* Toaster */,
 				03A75E4E1BCF20D4002E46C4 /* ToasterDemo */,
+				C06FC9D01F95A8CC00782082 /* ToasterTests */,
 			);
 		};
 /* End PBXProject section */
@@ -215,6 +269,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		03A75E4D1BCF20D4002E46C4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C06FC9CF1F95A8CC00782082 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -244,6 +305,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C06FC9CD1F95A8CC00782082 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C06FC9D41F95A8CC00782082 /* ToasterTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -251,6 +320,11 @@
 			isa = PBXTargetDependency;
 			target = 03A75E2A1BCF2066002E46C4 /* Toaster */;
 			targetProxy = 03A75E631BCF216A002E46C4 /* PBXContainerItemProxy */;
+		};
+		C06FC9D81F95A8CC00782082 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 03A75E2A1BCF2066002E46C4 /* Toaster */;
+			targetProxy = C06FC9D71F95A8CC00782082 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -440,6 +514,50 @@
 			};
 			name = Release;
 		};
+		C06FC9D91F95A8CC00782082 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = ToasterTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.loisdiqual.ToasterTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		C06FC9DA1F95A8CC00782082 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = ToasterTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.loisdiqual.ToasterTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -466,6 +584,15 @@
 			buildConfigurations = (
 				03A75E5F1BCF20D4002E46C4 /* Debug */,
 				03A75E601BCF20D4002E46C4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C06FC9DB1F95A8CC00782082 /* Build configuration list for PBXNativeTarget "ToasterTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C06FC9D91F95A8CC00782082 /* Debug */,
+				C06FC9DA1F95A8CC00782082 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Toaster.xcodeproj/xcshareddata/xcschemes/Toaster.xcscheme
+++ b/Toaster.xcodeproj/xcshareddata/xcschemes/Toaster.xcscheme
@@ -29,7 +29,26 @@
       language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C06FC9D01F95A8CC00782082"
+               BuildableName = "ToasterTests.xctest"
+               BlueprintName = "ToasterTests"
+               ReferencedContainer = "container:Toaster.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "03A75E2A1BCF2066002E46C4"
+            BuildableName = "Toaster.framework"
+            BlueprintName = "Toaster"
+            ReferencedContainer = "container:Toaster.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>

--- a/ToasterTests/Info.plist
+++ b/ToasterTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/ToasterTests/ToasterTests.swift
+++ b/ToasterTests/ToasterTests.swift
@@ -1,0 +1,46 @@
+//
+//  ToasterTests.swift
+//  ToasterTests
+//
+//  Created by Lois Di Qual on 10/16/17.
+//  Copyright © 2017 Suyeol Jeon. All rights reserved.
+//
+
+import XCTest
+
+@testable import Toaster
+
+class ToasterTests: XCTestCase {
+    
+    // Regression test for https://github.com/devxoul/Toaster/issues/111
+    func testCurrentToastIsNilAfterCancelAll() {
+        Toast(text: "text").show()
+        ToastCenter.default.cancelAll()
+        XCTAssertNil(ToastCenter.default.currentToast)
+    }
+    
+    // Regression test https://github.com/devxoul/Toaster/issues/107
+    func testFinishDoesNothingIfNotExecuting() {
+        
+        let toast = Toast(text: "text")
+        toast.show()
+        toast.finish()
+        XCTAssertFalse(toast.isExecuting)
+        XCTAssertFalse(toast.isCancelled)
+        XCTAssertFalse(toast.isFinished)
+    }
+    
+    func testCurrentToastShouldIgnoreFinishedAndCancelledToasts() {
+        
+        let toast1 = Toast(text: "text1")
+        toast1.show()
+        toast1.cancel()
+        
+        let toast2 = Toast(text: "text2")
+        toast2.show()
+        toast2.finish()
+        
+        XCTAssertNil(ToastCenter.default.currentToast)
+    }
+    
+}

--- a/ToasterTests/ToasterTests.swift
+++ b/ToasterTests/ToasterTests.swift
@@ -12,6 +12,11 @@ import XCTest
 
 class ToasterTests: XCTestCase {
     
+    override func tearDown() {
+        super.tearDown()
+        ToastCenter.default.cancelAll()
+    }
+    
     // Regression test for https://github.com/devxoul/Toaster/issues/111
     func testCurrentToastIsNilAfterCancelAll() {
         Toast(text: "text").show()
@@ -21,17 +26,21 @@ class ToasterTests: XCTestCase {
     
     func testCurrentToastShouldIgnoreFinishedAndCancelledToasts() {
         
+        // Show Toast 1, make sure it's the current toast
         let toast1 = Toast(text: "text1")
         toast1.show()
         XCTAssertEqual(ToastCenter.default.currentToast, toast1)
 
+        // Cancel Toast 1, make sure there's no current toast
         toast1.cancel()
         XCTAssertNil(ToastCenter.default.currentToast)
         
+        // Show Toast 2, make sure it's the current toast
         let toast2 = Toast(text: "text2", duration: 0.3)
         toast2.show()
         XCTAssertEqual(ToastCenter.default.currentToast, toast2)
         
+        // Wait for Toast 2 to finish
         let expectation = self.expectation(description: "Toast 2 should finish")
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
             expectation.fulfill()
@@ -39,7 +48,36 @@ class ToasterTests: XCTestCase {
         }
         wait(for: [expectation], timeout: 3)
         
+        // Make sure there's no current toast
         XCTAssertNil(ToastCenter.default.currentToast)
+    }
+    
+    func testBasicToast() {
+        
+        XCTAssertEqual(ToastWindow.shared.subviews.count, 0)
+        
+        let toast = Toast(text: "text", duration: 0.5)
+        toast.show()
+        
+        let appearExpectation = self.expectation(description: "Wait for toast to appear")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            appearExpectation.fulfill()
+            
+            XCTAssertEqual(ToastWindow.shared.subviews.count, 1)
+            guard let toastView = ToastWindow.shared.subviews.first as? ToastView else {
+                return XCTFail("Subview should be a ToastView")
+            }
+            
+            XCTAssertEqual(toastView.text, "text")
+        }
+        wait(for: [appearExpectation], timeout: 1)
+        
+        let disappearExpectation = self.expectation(description: "Wait for toast to disappear")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            disappearExpectation.fulfill()
+            XCTAssertEqual(ToastWindow.shared.subviews.count, 0)
+        }
+        wait(for: [disappearExpectation], timeout: 3)
     }
     
 }

--- a/ToasterTests/ToasterTests.swift
+++ b/ToasterTests/ToasterTests.swift
@@ -19,26 +19,25 @@ class ToasterTests: XCTestCase {
         XCTAssertNil(ToastCenter.default.currentToast)
     }
     
-    // Regression test https://github.com/devxoul/Toaster/issues/107
-    func testFinishDoesNothingIfNotExecuting() {
-        
-        let toast = Toast(text: "text")
-        toast.show()
-        toast.finish()
-        XCTAssertFalse(toast.isExecuting)
-        XCTAssertFalse(toast.isCancelled)
-        XCTAssertFalse(toast.isFinished)
-    }
-    
     func testCurrentToastShouldIgnoreFinishedAndCancelledToasts() {
         
         let toast1 = Toast(text: "text1")
         toast1.show()
+        XCTAssertEqual(ToastCenter.default.currentToast, toast1)
+
         toast1.cancel()
+        XCTAssertNil(ToastCenter.default.currentToast)
         
-        let toast2 = Toast(text: "text2")
+        let toast2 = Toast(text: "text2", duration: 0.3)
         toast2.show()
-        toast2.finish()
+        XCTAssertEqual(ToastCenter.default.currentToast, toast2)
+        
+        let expectation = self.expectation(description: "Toast 2 should finish")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            expectation.fulfill()
+            XCTAssertTrue(toast2.isFinished)
+        }
+        wait(for: [expectation], timeout: 3)
         
         XCTAssertNil(ToastCenter.default.currentToast)
     }


### PR DESCRIPTION
Fixes https://github.com/devxoul/Toaster/issues/111

This reverts https://github.com/devxoul/Toaster/pull/109 and subsequently will impact this issue: https://github.com/devxoul/Toaster/issues/107.

As of Toaster 2.0.4 `Toast.finish()` skips setting `isFinished=true` and `isExecuting=false` when the operation is not executing. This causes an issue where calling `cancel()` right after `show()` **will cause the operation queue to stall.**

On the same vibe, since `ToastCenter.currentToast` didn't exclude cancelled and finished tasks, calling `cancel()` right after `show()` would cause `currentToast` to not be nil.

### What's the bug

```
let toast = Toast(text: "text").show()
toast.cancel()
```

Since `show()` adds the operation to a background queue, it means `Toast.start` actually [postpones the `start()`](https://github.com/devxoul/Toaster/blob/master/Sources/Toast.swift#L117) which causes `cancel()` to be called **before** `start()`.

According to the [`cancel()` docs](https://developer.apple.com/documentation/foundation/operation#1661262):

 >You must change the value returned by isFinished to true and the value returned by isExecuting to false. You must make these changes even if the operation was cancelled before it started executing.

So `cancel()` needs to set `isFinished=true` and `isExecuting=false`. However in #109 we added a check that would prevent setting those flags if the operation is not executing. Since we're not setting those flags properly, the operation queue will call `start()` and wait for the operation to complete. However the operation will never complete because we ignore the start call if the operation is cancelled (see below).

Furthermore, according to `start()`'s documentation, we need to ignore finished/executing/cancelled operations because we're overriding the default implementation of `start()` which was performing those checks for us:

 >This method also performs several checks to ensure that the operation can actually run. For example, if the receiver was cancelled or is already finished, this method simply returns without calling main().

### The fix

 - Removed the `isExecuting` guard in `Toast.finish()`
 - Removed a `super.start()` call since the [docs](https://developer.apple.com/documentation/foundation/operation/1416837-start) specify that it must not be called

    >Your custom implementation must not call super at any time`

    Instead, we're calling `main()` from `start()` directly.
 - Since `ToastCenter.currentToast` would return finished/cancelled operations, I fixed it by filtering those out
 - Added basic unit tests to make sure those issues are fixed, as well as one basic test that introspects the shared window.

Let me know if you have any question!

