### PR TITLE
Fix issue of keyboard hiding toasts on iOS 11 (imperfect: work in progress)

### DIFF
--- a/Sources/ToastWindow.swift
+++ b/Sources/ToastWindow.swift
@@ -78,11 +78,23 @@ open class ToastWindow: UIWindow {
     fatalError("init(coder:) has not been implemented")
   }
 
+  override open func addSubview(_ view: UIView) {
+    super.addSubview(view)
+    moveToastToHighestWindow()
+  }
+
   /// Bring ToastWindow to top when another window is being shown.
   @objc func bringWindowToTop(_ notification: Notification) {
     if !(notification.object is ToastWindow) {
       ToastWindow.shared.isHidden = true
       ToastWindow.shared.isHidden = false
+    }
+    moveToastToHighestWindow()
+  }
+
+  private func moveToastToHighestWindow() {
+    if let highestWindow = UIApplication.shared.windows.last, highestWindow.windowLevel > windowLevel {
+      subviews.forEach { highestWindow.addSubview($0) }
     }
   }
 


### PR DESCRIPTION
This solution for #117 just **works**. No crash. 🎉
Demo included for testing (see #134 for the Demo change alone).
