### PR TITLE
Avoiding glitch with demo keyboard autocorrection

### DIFF
--- a/Demo/RootViewController.swift
+++ b/Demo/RootViewController.swift
@@ -55,6 +55,7 @@ class RespondingButton: UIButton, UIKeyInput {
     return true
   }
   var hasText: Bool = true
+  var autocorrectionType: UITextAutocorrectionType = .no
   func insertText(_ text: String) {}
   func deleteBackward() {}
 }


### PR DESCRIPTION
This will prevent the keyboard suggestions glitch in some versions of iOS (or Xcode).
<img width="323" alt="screen shot 2018-06-17 at 11 08 56 pm" src="https://user-images.githubusercontent.com/839992/41509249-95771788-7283-11e8-934b-f828d0f57428.png">
