### PR TITLE
windows are always sorted by windowLevel

### DIFF
--- a/Demo/AppDelegate.swift
+++ b/Demo/AppDelegate.swift
@@ -10,10 +10,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?
   ) -> Bool {
-    self.window = UIWindow(frame: UIScreen.main.bounds)
-    self.window!.backgroundColor = UIColor.white
-    self.window!.rootViewController = RootViewController()
-    self.window!.makeKeyAndVisible()
+    let window = UIWindow(frame: UIScreen.main.bounds)
+    self.window = window
+    window.backgroundColor = UIColor.white
+    window.rootViewController = RootViewController()
+    window.makeKeyAndVisible()
     return true
   }
 

--- a/Sources/ToastWindow.swift
+++ b/Sources/ToastWindow.swift
@@ -7,7 +7,7 @@ open class ToastWindow: UIWindow {
   /// Will not return `rootViewController` while this value is `true`. Or the rotation will be fucked in iOS 9.
   var isStatusBarOrientationChanging = false
 
-  /// Returns original subviews. `ToastWindow` overrides `addSubview()` to add an subview to the
+  /// Returns original subviews. `ToastWindow` overrides `addSubview()` to add a subview to the
   /// top window instead itself.
   private var originalSubviews = NSPointerArray.weakObjects()
 
@@ -156,15 +156,13 @@ open class ToastWindow: UIWindow {
 
   @objc func keyboardWillShow() {
     self.bringWindowToTop()
-    for subview in self.originalSubviews.allObjects {
-      guard let subview = subview as? UIView else { continue }
+    for subview in self.originalSubviews.allObjects as! [UIView] {
       self.addSubviewToTopWindow(subview: subview)
     }
   }
 
   @objc func keyboardDidHide() {
-    for subview in self.originalSubviews.allObjects {
-      guard let subview = subview as? UIView else { continue }
+    for subview in self.originalSubviews.allObjects as! [UIView] {
       super.addSubview(subview)
     }
   }
@@ -185,7 +183,7 @@ open class ToastWindow: UIWindow {
   }
 
   private func addSubviewToTopWindow(subview: UIView) {
-    if let window = UIApplication.shared.windows.max(by: { $0.windowLevel < $1.windowLevel }), window !== self {
+    if let window = UIApplication.shared.windows.last, window !== self {
       window.addSubview(subview)
     }
   }

--- a/Sources/ToastWindow.swift
+++ b/Sources/ToastWindow.swift
@@ -155,14 +155,16 @@ open class ToastWindow: UIWindow {
   }
 
   @objc func keyboardWillShow() {
-    self.bringWindowToTop()
-    for subview in self.originalSubviews.allObjects as! [UIView] {
-      self.addSubviewToTopWindow(subview: subview)
+    guard let topWindow = self.topWindow(),
+      let subviews = self.originalSubviews.allObjects as? [UIView] else { return }
+    for subview in subviews {
+      topWindow.addSubview(subview)
     }
   }
 
   @objc func keyboardDidHide() {
-    for subview in self.originalSubviews.allObjects as! [UIView] {
+    guard let subviews = self.originalSubviews.allObjects as? [UIView] else { return }
+    for subview in subviews {
       super.addSubview(subview)
     }
   }
@@ -179,13 +181,15 @@ open class ToastWindow: UIWindow {
   override open func addSubview(_ view: UIView) {
     super.addSubview(view)
     self.originalSubviews.addPointer(Unmanaged.passUnretained(view).toOpaque())
-    self.addSubviewToTopWindow(subview: view)
+    self.topWindow()?.addSubview(view)
   }
 
-  private func addSubviewToTopWindow(subview: UIView) {
+  /// Returns top window that isn't self
+  private func topWindow() -> UIWindow? {
     if let window = UIApplication.shared.windows.last, window !== self {
-      window.addSubview(subview)
+      return window
     }
+    return nil
   }
 
   /// Brings ToastWindow to top when another window is being shown.


### PR DESCRIPTION
* windows are always sorted by windowLevel (it's [in the doc](https://developer.apple.com/documentation/uikit/uiapplication/1623104-windows))
* originalSubviews is private, so the object type is always UIView: no need to guard
* typo