### PR TITLE
Fix missing @unknown default case

### DIFF
--- a/Sources/ToastView.swift
+++ b/Sources/ToastView.swift
@@ -42,22 +42,28 @@ open class ToastView: UIView {
   /// The bottom offset from the screen's bottom in portrait mode.
   @objc open dynamic var bottomOffsetPortrait: CGFloat = {
     switch UIDevice.current.userInterfaceIdiom {
-    case .unspecified: return 30
+    // specific values
     case .phone: return 30
     case .pad: return 60
     case .tv: return 90
     case .carPlay: return 30
+    // default values
+    case .unspecified: fallthrough
+    @unknown default: return 30
     }
   }()
 
   /// The bottom offset from the screen's bottom in landscape mode.
   @objc open dynamic var bottomOffsetLandscape: CGFloat = {
     switch UIDevice.current.userInterfaceIdiom {
-    case .unspecified: return 20
+    // specific values
     case .phone: return 20
     case .pad: return 40
     case .tv: return 60
     case .carPlay: return 20
+    // default values
+    case .unspecified: fallthrough
+    @unknown default: return 20
     }
   }()
 
@@ -77,11 +83,14 @@ open class ToastView: UIView {
     self.backgroundColor = .clear
     self.font = {
       switch UIDevice.current.userInterfaceIdiom {
-      case .unspecified: return .systemFont(ofSize: 12)
+      // specific values
       case .phone: return .systemFont(ofSize: 12)
       case .pad: return .systemFont(ofSize: 16)
       case .tv: return .systemFont(ofSize: 20)
       case .carPlay: return .systemFont(ofSize: 12)
+      // default values
+      case .unspecified: fallthrough
+      @unknown default: return .systemFont(ofSize: 12)
       }
     }()
     self.numberOfLines = 0


### PR DESCRIPTION
This change solves the Xcode 10.2 warning:
>Switch covers known cases, but 'UIUserInterfaceIdiom' may have additional unknown values, possibly added in future versions

The syntax is at least compatible with Swift 4.2 and Swift 5.0.