### PR TITLE
Support VoiceOver

### DIFF
--- a/Sources/Toast.swift
+++ b/Sources/Toast.swift
@@ -126,6 +126,11 @@ open class Toast: Operation {
           self.view.alpha = 1
         },
         completion: { completed in
+          #if swift(>=4.2)
+          UIAccessibility.post(notification: .announcement, argument: self.view.text)
+          #else
+          UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, self.view.text)
+          #endif
           UIView.animate(
             withDuration: self.duration,
             animations: {

--- a/Sources/Toast.swift
+++ b/Sources/Toast.swift
@@ -126,11 +126,13 @@ open class Toast: Operation {
           self.view.alpha = 1
         },
         completion: { completed in
-          #if swift(>=4.2)
-          UIAccessibility.post(notification: .announcement, argument: self.view.text)
-          #else
-          UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, self.view.text)
-          #endif
+          if ToastCenter.default.isSupportAccessibility {
+            #if swift(>=4.2)
+            UIAccessibility.post(notification: .announcement, argument: self.view.text)
+            #else
+            UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, self.view.text)
+            #endif
+          }
           UIView.animate(
             withDuration: self.duration,
             animations: {

--- a/Sources/ToastCenter.swift
+++ b/Sources/ToastCenter.swift
@@ -13,7 +13,11 @@ open class ToastCenter {
   open var currentToast: Toast? {
     return self.queue.operations.first { !$0.isCancelled && !$0.isFinished } as? Toast
   }
-
+  
+  /// If this value is `true` and the user is using VoiceOver,
+  /// VoiceOver will announce the text in the toast when `ToastView` is displayed.
+  public var isSupportAccessibility: Bool = true
+  
   public static let `default` = ToastCenter()
 
 


### PR DESCRIPTION
I think we have to support voice over. #128 
There are two approach.

1. Use `UIAccessibility.Notification.announcement`
It does not moves focus on `ToastView`, but voice over read the text directly.

2. Use `UIAccessibility.Notification.screenChanged`
It moves focus on ToastView, and read text on `ToastView.
However, a user may lose the context in which she or he is using.

Therefore, I choose first approach.