### PR TITLE
Add queue enable option

### DIFF
--- a/Sources/ToastCenter.swift
+++ b/Sources/ToastCenter.swift
@@ -18,6 +18,8 @@ open class ToastCenter: NSObject {
   /// VoiceOver will announce the text in the toast when `ToastView` is displayed.
   @objc public var isSupportAccessibility: Bool = true
   
+  /// By default, queueing for toast is enabled.
+  /// If this value is `false`, only the last requested toast will be shown.
   @objc public var isQueueEnabled: Bool = true
   
   @objc public static let `default` = ToastCenter()

--- a/Sources/ToastCenter.swift
+++ b/Sources/ToastCenter.swift
@@ -18,6 +18,8 @@ open class ToastCenter: NSObject {
   /// VoiceOver will announce the text in the toast when `ToastView` is displayed.
   @objc public var isSupportAccessibility: Bool = true
   
+  @objc public var isQueueEnabled: Bool = true
+  
   @objc public static let `default` = ToastCenter()
 
 
@@ -42,6 +44,9 @@ open class ToastCenter: NSObject {
   // MARK: Adding Toasts
 
   open func add(_ toast: Toast) {
+    if !isQueueEnabled {
+      cancelAll()
+    }
     self.queue.addOperation(toast)
   }
 


### PR DESCRIPTION
In my service, I want to delete old toasts and only display the latest toast.
I tried to implement it in two ways.

### 1. changing queue setting.
```swift
queue.maxConcurrentOperationCount = OperationQueue.defaultMaxConcurrentOperationCount
```
However, this setting overlaps the toasts when displaying multiple toasts.
I think the toast overlaps, making it harder for users to understand the information.

### 2. using `cancelAll()`
This will only show the last toast requested.
I think this is better way.