### PR TITLE
Fix toast width calculation with insets

### DIFF
--- a/Sources/ToastView.swift
+++ b/Sources/ToastView.swift
@@ -124,7 +124,7 @@ open class ToastView: UIView {
     super.layoutSubviews()
     let containerSize = ToastWindow.shared.frame.size
     let constraintSize = CGSize(
-      width: containerSize.width * (280.0 / 320.0),
+      width: containerSize.width * (280.0 / 320.0) - self.textInsets.left - self.textInsets.right,
       height: CGFloat.greatestFiniteMagnitude
     )
     let textLabelSize = self.textLabel.sizeThatFits(constraintSize)


### PR DESCRIPTION
This PR fix toast width calculation with insets.

For example,
```swift
ToastView.appearance().textInsets = UIEdgeInsets(top: 15, left: 100, bottom: 15, right: 100)
Toast(text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.").show()
```
|  BEFORE	|  AFTER	|
|---	|---	|
|  <img src="https://user-images.githubusercontent.com/11647461/62752304-e40bf280-baa1-11e9-9d7a-7f478937d211.png" width=300>	|  <img src="https://user-images.githubusercontent.com/11647461/62752388-482eb680-baa2-11e9-92d3-b74d2f45e80c.png" width=300>	|