### PR TITLE
Prevent to be keyWindow

### DIFF
--- a/Sources/ToastWindow.swift
+++ b/Sources/ToastWindow.swift
@@ -2,7 +2,7 @@ import UIKit
 
 open class ToastWindow: UIWindow {
 
-  public static let shared = ToastWindow(frame: UIScreen.main.bounds)
+  public static let shared = ToastWindow(frame: UIScreen.main.bounds, mainWindow: UIApplication.shared.keyWindow)
 
   /// Will not return `rootViewController` while this value is `true`. Or the rotation will be fucked in iOS 9.
   var isStatusBarOrientationChanging = false
@@ -52,9 +52,12 @@ open class ToastWindow: UIWindow {
     }
     set { /* Do nothing */ }
   }
+  
+  private weak var mainWindow: UIWindow?
 
-  public override init(frame: CGRect) {
+  public init(frame: CGRect, mainWindow: UIWindow?) {
     super.init(frame: frame)
+    self.mainWindow = mainWindow
     self.isUserInteractionEnabled = false
     self.gestureRecognizers = nil
     #if swift(>=4.2)
@@ -192,6 +195,11 @@ open class ToastWindow: UIWindow {
         isShowing = false
       }
     }
+  }
+  
+  open override func becomeKey() {
+    super.becomeKey()
+    mainWindow?.makeKey()
   }
 
   /// Returns top window that isn't self


### PR DESCRIPTION
## Background

I haven't figured out why this bug happens.
When using Toaster, sometimes the ToasterWindow becomes a keyWindow.

![스크린샷 2019-08-23 오전 12 46 57](https://user-images.githubusercontent.com/11647461/63529635-f1b08600-c53f-11e9-8fac-fca3602a07e9.png)

In this situation, the call to `UITextView.becomeFirstResponder()` may not bring up the keyboard.
Also, if we have code written based on keyWindow, it will work unexpectedly.

## Fix
Therefore, I want to change code to prevent `ToasterWindow` to be `keyWindow`.
I referenced this [link](https://stackoverflow.com/a/38116113).