### PR TITLE
Fix keyboard flag

### DIFF
--- a/Sources/ScreenObserver.h
+++ b/Sources/ScreenObserver.h
@@ -1,0 +1,28 @@
+//
+//  ScreenObserver.h
+//  Toaster
+//
+//  Created by 홍성호 on 27/08/2019.
+//  Copyright © 2019 Suyeol Jeon. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class ScreenObserver;
+@protocol ScreenObserverDelegate
+- (void)screenObserver:(ScreenObserver *)screenObserver statusBarOrientationWillChange:(NSNotification*)notification;
+- (void)screenObserver:(ScreenObserver *)screenObserver statusBarOrientationDidChange:(NSNotification*)notification;
+- (void)screenObserver:(ScreenObserver *)screenObserver applicationDidBecomeActive:(NSNotification*)notification;
+- (void)screenObserver:(ScreenObserver *)screenObserver keyboardWillShow:(NSNotification*)notification;
+- (void)screenObserver:(ScreenObserver *)screenObserver keyboardDidHide:(NSNotification*)notification;
+@end
+
+@interface ScreenObserver : NSObject
+@property (nonatomic, weak) id<ScreenObserverDelegate> delegate;
+@property (nonatomic, assign) BOOL didKeyboardShow;
++ (instancetype)shared;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/ScreenObserver.m
+++ b/Sources/ScreenObserver.m
@@ -1,0 +1,77 @@
+//
+//  ScreenObserver.m
+//  Toaster
+//
+//  Created by 홍성호 on 27/08/2019.
+//  Copyright © 2019 Suyeol Jeon. All rights reserved.
+//
+
+#import "ScreenObserver.h"
+#import <UIKit/UIKit.h>
+
+@implementation ScreenObserver
+
++ (void)load {
+    [ScreenObserver shared];
+}
+
++ (instancetype)shared {
+    static ScreenObserver *shared = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        shared = [[self alloc] init];
+    });
+    return shared;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+        [center addObserver:self
+                   selector:@selector(statusBarOrientationWillChange:)
+                       name:UIApplicationWillChangeStatusBarFrameNotification
+                     object:nil];
+        [center addObserver:self
+                   selector:@selector(statusBarOrientationDidChange:)
+                       name:UIApplicationDidChangeStatusBarOrientationNotification
+                     object:nil];
+        [center addObserver:self
+                   selector:@selector(applicationDidBecomeActive:)
+                       name:UIApplicationDidBecomeActiveNotification
+                     object:nil];
+        [center addObserver:self
+                   selector:@selector(keyboardWillShow:)
+                       name:UIKeyboardWillShowNotification
+                     object:nil];
+        [center addObserver:self
+                   selector:@selector(keyboardDidHide:)
+                       name:UIKeyboardDidHideNotification
+                     object:nil];
+    }
+    return self;
+}
+
+- (void)statusBarOrientationWillChange:(NSNotification*)notification {
+    [self.delegate screenObserver:self statusBarOrientationWillChange:notification];
+}
+
+- (void)statusBarOrientationDidChange:(NSNotification*)notification {
+    [self.delegate screenObserver:self statusBarOrientationDidChange:notification];
+}
+
+- (void)applicationDidBecomeActive:(NSNotification*)notification {
+    [self.delegate screenObserver:self applicationDidBecomeActive:notification];
+}
+
+- (void)keyboardWillShow:(NSNotification*)notification {
+    self.didKeyboardShow = YES;
+    [self.delegate screenObserver:self keyboardWillShow:notification];
+}
+
+- (void)keyboardDidHide:(NSNotification*)notification {
+    self.didKeyboardShow = NO;
+    [self.delegate screenObserver:self keyboardDidHide:notification];
+}
+
+@end

--- a/Sources/ToastWindow.swift
+++ b/Sources/ToastWindow.swift
@@ -178,6 +178,7 @@ open class ToastWindow: UIWindow {
   }
 
   @objc private func keyboardDidHide() {
+    didKeyboardShow = false
     guard let subviews = self.originalSubviews.allObjects as? [UIView] else { return }
     for subview in subviews {
       super.addSubview(subview)

--- a/Sources/Toaster.h
+++ b/Sources/Toaster.h
@@ -2,3 +2,5 @@
 
 FOUNDATION_EXPORT double ToasterVersionNumber;
 FOUNDATION_EXPORT const unsigned char ToasterVersionString[];
+
+#import "ScreenObserver.h"

--- a/Toaster.xcodeproj/project.pbxproj
+++ b/Toaster.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		3719A73F2255991B009EAFCD /* Toaster.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 03A75E2B1BCF2066002E46C4 /* Toaster.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C06FC9D41F95A8CC00782082 /* ToasterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06FC9D31F95A8CC00782082 /* ToasterTests.swift */; };
 		C06FC9D61F95A8CC00782082 /* Toaster.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03A75E2B1BCF2066002E46C4 /* Toaster.framework */; };
+		C11E633923143249009FF2A9 /* ScreenObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = C11E633723143249009FF2A9 /* ScreenObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C11E633A23143249009FF2A9 /* ScreenObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = C11E633823143249009FF2A9 /* ScreenObserver.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -104,6 +106,8 @@
 		C06FC9D11F95A8CC00782082 /* ToasterTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ToasterTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C06FC9D31F95A8CC00782082 /* ToasterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToasterTests.swift; sourceTree = "<group>"; };
 		C06FC9D51F95A8CC00782082 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C11E633723143249009FF2A9 /* ScreenObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScreenObserver.h; sourceTree = "<group>"; };
+		C11E633823143249009FF2A9 /* ScreenObserver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ScreenObserver.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -161,6 +165,8 @@
 				0306DBA71D85D62A007AE314 /* ToastCenter.swift */,
 				0306DBA81D85D62A007AE314 /* ToastView.swift */,
 				0306DBA91D85D62A007AE314 /* ToastWindow.swift */,
+				C11E633723143249009FF2A9 /* ScreenObserver.h */,
+				C11E633823143249009FF2A9 /* ScreenObserver.m */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -227,6 +233,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C11E633923143249009FF2A9 /* ScreenObserver.h in Headers */,
 				0306DBAA1D85D62A007AE314 /* Toaster.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -320,7 +327,7 @@
 				TargetAttributes = {
 					03A75E2A1BCF2066002E46C4 = {
 						CreatedOnToolsVersion = 7.0.1;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1030;
 					};
 					03A75E4E1BCF20D4002E46C4 = {
 						CreatedOnToolsVersion = 7.0.1;
@@ -397,6 +404,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C11E633A23143249009FF2A9 /* ScreenObserver.m in Sources */,
 				0306DBAC1D85D62A007AE314 /* ToastCenter.swift in Sources */,
 				0306DBAE1D85D62A007AE314 /* ToastWindow.swift in Sources */,
 				0306DBAB1D85D62A007AE314 /* Toast.swift in Sources */,
@@ -602,7 +610,9 @@
 				PRODUCT_BUNDLE_IDENTIFIER = kr.xoul.Toaster;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -623,7 +633,9 @@
 				PRODUCT_BUNDLE_IDENTIFIER = kr.xoul.Toaster;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
This PR fix #152 again 😅
Currently on master branch, we have a bug.

![keyboardFlag](https://user-images.githubusercontent.com/11647461/63604707-6e5a6780-c607-11e9-8456-3b15c46655b2.gif)

1. Show Toast
Start keyboard observering
2. Show Keyboard
`keyboardDidShow` = true
3. Open ImagePicker and Select image
`UIRemoteKeyboardWindow` is now `topWindow`
https://github.com/devxoul/Toaster/blob/7d4afaaa3e610e8738eea178b44b7cd1db40f2fa/Sources/ToastWindow.swift#L207-L215
4. Show Toast not working
Actually, ToastView is added on invisible `UIRemoteKeyboardWindow`


Therefore I fix `keyboardDidShow` flag to change when keyboard is hidden.