### PR TITLE
Update status bar style after rotation

### DIFF
--- a/Demo/RootViewController.swift
+++ b/Demo/RootViewController.swift
@@ -4,6 +4,10 @@ import Photos
 
 final class RootViewController: UIViewController {
 
+  override var preferredStatusBarStyle: UIStatusBarStyle {
+    .lightContent
+  }
+  
   override func viewDidLoad() {
     let button = UIButton(type: .system)
     button.setTitle("Show", for: .normal)

--- a/Sources/ToastWindow.swift
+++ b/Sources/ToastWindow.swift
@@ -159,6 +159,7 @@ open class ToastWindow: UIWindow {
     let orientation = UIApplication.shared.statusBarOrientation
     self.handleRotate(orientation)
     self.isStatusBarOrientationChanging = false
+    rootViewController?.setNeedsStatusBarAppearanceUpdate()
   }
 
   @objc private func applicationDidBecomeActive() {


### PR DESCRIPTION
## Issue
When we rotate device while presenting ToastWindow, the status bar style is not updated.

## PR
Update status bar style when didChangeStatusBarOrientationNotification called.