### PR TITLE
Allow build for Xcode versions prior Xcode 12

### DIFF
--- a/Sources/ToastView.swift
+++ b/Sources/ToastView.swift
@@ -52,7 +52,7 @@ open class ToastView: UIView {
     case .pad: return 60
     case .tv: return 90
     case .carPlay: return 30
-    #if swift(>=5.3)
+    #if compiler(>=5.3)
     case .mac: return 60
     #endif
     // default values
@@ -69,7 +69,7 @@ open class ToastView: UIView {
     case .pad: return 40
     case .tv: return 60
     case .carPlay: return 20
-    #if swift(>=5.3)
+    #if compiler(>=5.3)
     case .mac: return 40
     #endif
     // default values
@@ -138,7 +138,7 @@ open class ToastView: UIView {
       case .pad: return .systemFont(ofSize: 16)
       case .tv: return .systemFont(ofSize: 20)
       case .carPlay: return .systemFont(ofSize: 12)
-      #if swift(>=5.3)
+      #if compiler(>=5.3)
       case .mac: return .systemFont(ofSize: 16)
       #endif
       // default values

--- a/Sources/ToastView.swift
+++ b/Sources/ToastView.swift
@@ -52,7 +52,9 @@ open class ToastView: UIView {
     case .pad: return 60
     case .tv: return 90
     case .carPlay: return 30
+    #if swift(>=5.3)
     case .mac: return 60
+    #endif
     // default values
     case .unspecified: fallthrough
     @unknown default: return 30
@@ -67,7 +69,9 @@ open class ToastView: UIView {
     case .pad: return 40
     case .tv: return 60
     case .carPlay: return 20
+    #if swift(>=5.3)
     case .mac: return 40
+    #endif
     // default values
     case .unspecified: fallthrough
     @unknown default: return 20
@@ -134,7 +138,9 @@ open class ToastView: UIView {
       case .pad: return .systemFont(ofSize: 16)
       case .tv: return .systemFont(ofSize: 20)
       case .carPlay: return .systemFont(ofSize: 12)
+      #if swift(>=5.3)
       case .mac: return .systemFont(ofSize: 16)
+      #endif
       // default values
       case .unspecified: fallthrough
       @unknown default: return .systemFont(ofSize: 12)


### PR DESCRIPTION
`.mac` case comes for iOS 14 with Xcode 12 & swift 5.3.

This allows the compilation with older Xcode versions (prior Xcode 12) that come with an older Swift compiler version.