### PR TITLE
Bumping up deployment target version to iOS9.0 to avoid buildtime warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Toaster",
     platforms: [
-        .iOS(.v8)
+        .iOS(.v9)
     ],
     products: [
         .library(


### PR DESCRIPTION
With today's master, when you build with Xcode 12, you're getting this warning in the build time:
![Screenshot 2021-05-26 at 12 51 41](https://user-images.githubusercontent.com/1670172/119648143-643f4b80-be21-11eb-8d31-3dbbcf6bbb3f.png)

Suggested solution is to just bump it up to iOS 9.0 from iOS 8.0