### PR TITLE
Fix landscape rotation on iOS 16

### DIFF
--- a/Sources/ToastWindow.swift
+++ b/Sources/ToastWindow.swift
@@ -183,7 +183,7 @@ open class ToastWindow: UIWindow {
   
   private func handleRotate(_ orientation: UIInterfaceOrientation) {
     let angle = self.angleForOrientation(orientation)
-    if self.shouldRotateManually {
+    if #unavailable(iOS 16.0), self.shouldRotateManually {
       self.transform = CGAffineTransform(rotationAngle: CGFloat(angle))
     }
     


### PR DESCRIPTION
On iOS 16 the view transforms automatically so there's no need to manually transform it.